### PR TITLE
Add two free system-design interview tools (capacity estimator, rate limiter designer)

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -58,6 +58,8 @@ Started By Gabriel Leon de Mattos
 
 - [System Design Capacity Estimator](https://amanksingh.com/tools/system-design-capacity-estimator) - A free tool for the back-of-the-envelope estimation step of an interview: turns daily active users into average and peak QPS, storage growth, and read bandwidth.
 
+- [Rate Limiter Designer](https://amanksingh.com/tools/rate-limiter-designer) - A free tool that turns a requests-per-period limit into token-bucket parameters (capacity and refill rate), with notes on the token bucket vs fixed vs sliding window trade-off common in interviews.
+
 ## Advanced
 
 - [Distributed Computing](https://en.wikipedia.org/wiki/Distributed_computing) - Wikipedia article broadening the view of distributed system design.

--- a/readme.md
+++ b/readme.md
@@ -56,6 +56,8 @@ Started By Gabriel Leon de Mattos
 
 - [Practice system design problems using AI on Codemia.io](https://codemia.io) - A tool which allows you to practice system design problems interactively like an interview with AI. There's iterative feedback and final evaluation which scores your performance
 
+- [System Design Capacity Estimator](https://amanksingh.com/tools/system-design-capacity-estimator) - A free tool for the back-of-the-envelope estimation step of an interview: turns daily active users into average and peak QPS, storage growth, and read bandwidth.
+
 ## Advanced
 
 - [Distributed Computing](https://en.wikipedia.org/wiki/Distributed_computing) - Wikipedia article broadening the view of distributed system design.


### PR DESCRIPTION
Adds two free, client-side tools to the Introduction / Interviews section, alongside the existing interactive practice tools (e.g. Codemia):

- [System Design Capacity Estimator](https://amanksingh.com/tools/system-design-capacity-estimator) — turns daily active users into average/peak QPS, storage, and bandwidth (the back-of-the-envelope estimation step).
- [Rate Limiter Designer](https://amanksingh.com/tools/rate-limiter-designer) — converts a rate limit into token-bucket parameters, with the token bucket vs fixed/sliding window trade-off.

Both are free, no signup, run entirely in the browser, and cover topics that come up directly in system design interviews. Entries follow the section's format and placement. Thanks for maintaining this list!